### PR TITLE
Auto bind to `Caddyfile`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "printWidth": 90
+}

--- a/package.json
+++ b/package.json
@@ -1,37 +1,38 @@
 {
-    "name": "vscode-caddyfile-syntax",
-    "version": "1.0.1",
-    "displayName": "Caddyfile Syntax",
-    "description": "Adds syntax highlighting for Caddyfiles.",
-    "publisher": "zamerick",
-    "repository": "https://github.com/Zamerick/vscode-caddyfile-syntax",
-    "license": "MIT",
-    "engines": {
-        "vscode": "^1.19.0"
-    },
-    "categories": [
-        "Languages"
-    ],
-    "contributes": {
-        "languages": [
-            {
-                "id": "caddyfile",
-                "aliases": [
-                    "Caddyfile",
-                    "caddyfile"
-                ],
-                "extensions": [
-                    ""
-                ],
-                "configuration": "./language-configuration.json"
-            }
+  "name": "vscode-caddyfile-syntax",
+  "version": "1.0.1",
+  "displayName": "Caddyfile Syntax",
+  "description": "Adds syntax highlighting for Caddyfiles.",
+  "publisher": "zamerick",
+  "repository": "https://github.com/Zamerick/vscode-caddyfile-syntax",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.19.0"
+  },
+  "categories": [
+    "Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "caddyfile",
+        "aliases": [
+          "Caddyfile",
+          "caddyfile"
         ],
-        "grammars": [
-            {
-                "language": "caddyfile",
-                "scopeName": "source.Caddyfile",
-                "path": "./syntaxes/caddyfile.tmLanguage.json"
-            }
-        ]
-    }
+        "extensions": [
+          "Caddyfile",
+          "caddyfile"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "caddyfile",
+        "scopeName": "source.Caddyfile",
+        "path": "./syntaxes/caddyfile.tmLanguage.json"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
In order for Visual Studio Code to automatically bind our `Caddyfile` to this extension we need to define the desired files or extensions to bind with in the `package.json`.

That way the user does not need to update his/her configuration to something similar:
```json
  "files.associations": {
    "Caddyfile": "caddyfile"
  }
```

That would also improve the UX for those that are not seeing syntax highlighting after installing this extension.

_**Notes:** I also added `.prettierrc` to standardize the js/json formats._

Thanks for your work.